### PR TITLE
[README 충돌 유도] 팀원 이름 수정 

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,5 +146,5 @@ git push origin v1.0.0
 
 - 민수 (팀장): 저장소 초기화, 태그 생성, 최종 병합
 - 지윤 (기획자): 이슈/마일스톤/라벨 기획, 팀 규칙 정리
-- 건우 (개발자 A): `book_list.txt` 작성
+- 견우 (개발자 A): `book_list.txt` 리뷰 작성
 - 건하 (개발자 B): `markdown_guide.txt` 작성, 리뷰 및 회고


### PR DESCRIPTION
충돌 유도를 위하여 README.md 파일에서 팀원 이름 건우->견우 로 수정하고 그 뒤에 작성->리뷰 작성으로 구체화 하였습니다.

Resolves: #7 